### PR TITLE
Replace 'getopt' with 'argparse'

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 99

--- a/mail-tls-helper.py
+++ b/mail-tls-helper.py
@@ -19,8 +19,7 @@ import os
 import re
 import datetime
 import sqlite3
-import getopt
-import sys
+import argparse
 from collections import defaultdict
 from subprocess import call
 from subprocess import Popen, PIPE
@@ -33,9 +32,6 @@ name = "mail-tls-helper.py"
 version = "0.8.1"
 
 alertTTL = 30
-
-global op
-op = {}
 
 
 # Structure for pidDict
@@ -54,80 +50,58 @@ def pidFactory():
 
 
 # Parse options
-def options(args):
-    op['printHelp'] = False
-    op['printVersion'] = False
+def parse_args():
+    description = '''Postfix helper script that does the following:
+ * make TLS mandatory for outgoing mail wherever possible and
+ * optionally alert postmasters of mailservers that do not support STARTTLS'''
+    parser = argparse.ArgumentParser(prog=name, description=description,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--version', action='version', version='%(prog)s {}'.format(version))
+    parser.add_argument('--debug', action='store_true',
+                        help="run in debugging mode, don't do anything")
+    parser.add_argument('-m', '--mode', choices=('postfix', ), default='postfix',
+                        help='mode (currently only "postfix")')
+    parser.add_argument('-l', '--mail-log', type=str, dest='mail_logfile',
+                        default='/var/log/mail.log.1', help='mail log file')
+    parser.add_argument('-w', '--whitelist', type=str, dest='whitelist_filename',
+                        help='optional file containing relay whitelist')
+    parser.add_argument('-p', '--postfix-map-file', dest='postfix_map_file', type=str,
+                        default='/etc/postfix/tls_policy', help='Postfix TLS policy map file')
+    parser.add_argument('-s', '--sqlite-db', dest='sqlite_db',
+                        default='/var/lib/mail-tls-helper/notls.sqlite',
+                        help='SQLite DB file for internal state storage (created if missing)')
+    parser.add_argument('-a', '--alerts', dest='send_alerts', action='store_true',
+                        help=('send out alert mails to the "postmaster" addresses of external '
+                              'mail domains lacking TLS support'))
+    parser.add_argument('-S', '--no-summary', dest='send_summary', action='store_false',
+                        help='do not send out summary mail')
+    parser.add_argument('-P', '--no-postfix-map', dest='use_postfix_map', action='store_false',
+                        help='do not update the Postfix TLS policy map file')
+    parser.add_argument('-O', '--no-postmap', dest='run_postmap', action='store_false',
+                        help='do not "postmap(1)" the Postfix TLS policy map file')
+    parser.add_argument('-d', '--domain', type=str, default='example.org',
+                        help=('the organization domain is used for defaults of "-r" and "-f" and '
+                              'within the alert mail text body'))
+    parser.add_argument('-f', '--from', type=str, dest='from_address',
+                        help='sender/from mail address (default: "admin@DOMAIN", see "--domain")')
+    parser.add_argument('-r', '--rcpts', action='append', dest='recipients', help=(
+        'summary mail recipient address (default: "admin@DOMAIN", see "--domain")'))
 
-    try:
-        opts, args = getopt.getopt(args, 'ad:f:hl:m:Op:Pr:s:SVw:', [
-            'alerts', 'domain=', 'debug', 'from=', 'help', 'mail-log=', 'mode=', 'no-postmap',
-            'postfix-map-file=', 'no-postfix-map', 'rcpts=', 'sqlite-db=', 'no-summary', 'version',
-            'whitelist='])
-    except getopt.error as exc:
-        print("%s: %s, try -h for a list of all the options" % (name, str(exc)), file=sys.stderr)
-        sys.exit(255)
-
-    for opt, arg in opts:
-        if opt in ['-h', '--help']:
-            op['printHelp'] = True
-            break
-        elif opt in ['-V', '--version']:
-            op['printVersion'] = True
-            break
-        elif opt in ['-m', '--mode']:
-            if (arg == 'postfix'):
-                op['mode'] = arg
-            else:
-                print("%s: unknon mode %s, try -h for a list of all the options" % (name, arg),
-                      file=sys.stderr)
-                sys.exit(255)
-        elif opt in ['--debug']:
-            op['debug'] = True
-        elif opt in ['-l', '--mail-log']:
-            op['mailLog'] = arg
-        elif opt in ['-w', '--whitelist']:
-            op['whitelist'] = arg
-        elif opt in ['-P', '--no-postfix-map']:
-            op['postfixMap'] = False
-        elif opt in ['-p', '--postfix-map-file']:
-            op['postfixMapFile'] = arg
-        elif opt in ['-O', '--no-postmap']:
-            op['postMap'] = False
-        elif opt in ['-s', '--sqlite-db']:
-            op['sqliteDB'] = arg
-        elif opt in ['-a', '--alerts']:
-            op['alerts'] = True
-        elif opt in ['-S', '--no-summary']:
-            op['summary'] = False
-        elif opt in ['-d', '--domain']:
-            op['domain'] = arg
-        elif opt in ['-f', '--from']:
-            op['from'] = arg
-        elif opt in ['-r', '--rcpts']:
-            op['rcpts'] = arg.split(',')
-
-    # Set options to defaults if not set yet
-    op['debug'] = op.get('debug', False)
-    op['mode'] = op.get('mode', "postfix")
-    op['mailLog'] = op.get('mailLog', "/var/log/mail.log.1")
-    op['whitelist'] = op.get('whitelist', False)
-    op['postfixMap'] = op.get('postfixMap', True)
-    op['postfixMapFile'] = op.get('postfixMapFile', "/etc/postfix/tls_policy")
-    op['postMap'] = op.get('postMap', True)
-    op['sqliteDB'] = op.get('sqliteDB', "/var/lib/mail-tls-helper/notls.sqlite")
-    op['alerts'] = op.get('alerts', False)
-    op['summary'] = op.get('summary', True)
-    op['domain'] = op.get('domain', "example.org")
-    op['from'] = op.get('from', "admin@%s" % op['domain'])
-    op['rcpts'] = op.get('rcpts', ["admin@%s" % op['domain']])
-    op['summSubj'] = op.get('sumSubj', "[%s] mail-tls-helper summary" % (os.uname()[1]))
-    op['summBody'] = op.get('sumSubj', "Summary mail by mail-tls-helper on %s" % (os.uname()[1]))
-    op['alertSubj'] = op.get('alertSubj',
-                             "Please add TLS support to the mailservers for 'XDOMAINX'")
-    op['alertBody'] = op.get('alertBody', """Hello postmaster for mail domain 'XDOMAINX',
+    args = parser.parse_args()
+    # set some non-trivial defaults
+    if not args.from_address:
+        args.from_address = 'admin@{}'.format(args.domain)
+    if not args.recipients:
+        args.recipients = ['admin@{}'.format(args.domain)]
+    # add details that are currently not configurable
+    # This is a slight abuse of the arguments namespace, but this should be acceptable.
+    args.summary_subject = '[{}] mail-tls-helper summary'.format(os.uname()[1])
+    args.summary_start = 'Summary mail by mail-tls-helper on {}'.format(os.uname()[1])
+    args.alert_subject = "Please add TLS support to the mailservers for 'XDOMAINX'"
+    args.alert_body = """Hello postmaster for mail domain 'XDOMAINX',
 
 Your mail server for 'XDOMAINX' is among the last mail servers,
-that still don't support TLS transport encryption for incoming messages.
+that still do not support TLS transport encryption for incoming messages.
 
 
 In order to make the internet a safer place, we intend to disable
@@ -139,45 +113,15 @@ to your mail setup.
 See RFC 3207 for further information: https://tools.ietf.org/html/rfc3207
 
 In case of any questions, don't hesitate to contact us at
-%s
+{from_address}
 
 Kind regards,
-%s sysadmins
-""" % (op['from'], op['domain']))
-
-    if op['printHelp']:
-        print("usage: %s [options]" % name, file=sys.stderr)
-        print("""
-Postfix helper script that does the following:
- * make TLS mandatory for outgoing mail wherever possible and
- * optionally alert postmasters of mailservers that don't support STARTTLS
-
-%s options:
-  -h, --help                   display this help message
-  -V, --version                display version number
-      --debug                  run in debugging mode, don't do anything
-  -m, --mode=[postfix]         set mode (default: %s, no others supported yet)
-  -l, --mail-log=file          set mail log file (default: %s)
-  -w, --whitelist=file         file containing relay whitelist
-  -p, --postfix-map-file=file  set Postfix TLS policy map file (default: %s)
-  -s, --sqlite-db=file         set SQLite DB file (default: %s)
-  -a, --alerts                 send out alert mails
-  -S, --no-summary             don't send out summary mail
-  -P, --no-postfix-map         don't update the Postfix TLS policy map file
-  -O, --no-postmap             don't postmap(1) the Postfix TLS policy map file
-  -d, --domain=name            set organization domain (default: %s)
-  -f, --from=address           set sender address (default: %s)
-  -r, --rcpts=addresses        set summary mail rcpt addresses (default: %s)
-""" % (name, op['mode'], op['mailLog'], op['postfixMapFile'], op['sqliteDB'], op['domain'],
-            op['from'], ','.join(op['rcpts'])), file=sys.stderr)
-        sys.exit(0)
-    elif op['printVersion']:
-        print("%s %s" % (name, version), file=sys.stderr)
-        sys.exit(0)
+{domain} sysadmins""".format(from_address=args.from_address, domain=args.domain)
+    return args
 
 
 def print_dbg(msg):
-    if op['debug']:
+    if args.debug:
         print("DEBUG: %s" % msg)
 
 
@@ -203,15 +147,15 @@ def postfixTlsPolicyUpdate(domainsTLS, postfixMapFile, postMap):
         for domain in domainsTLS:
             if domain not in policyFileLines:
                 print_dbg("Add domain '%s' to Postfix TLS policy map" % domain)
-                if not op['debug']:
+                if not args.debug:
                     policyFile.write("%s encrypt\n" % domain)
         policyFile.close()
 
-    if postMap and not op['debug']:
+    if postMap and not args.debug:
         call(["postmap", postfixMapFile])
 
 
-def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
+def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB, summary_lines):
     domainDBNoTLS = {}
     if os.path.isfile(sqliteDB):
         conn = sqlite3.connect(sqliteDB)
@@ -225,7 +169,7 @@ def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
                 'alertDate': item[2],
             }
 
-    op['summBody'] += "\nList of domains with no-TLS connections:"
+    summary_lines.append("List of domains with no-TLS connections:")
     conn = sqlite3.connect(sqliteDB)
     c = conn.cursor()
     c.execute('CREATE TABLE IF NOT EXISTS notlsDomains '
@@ -233,7 +177,7 @@ def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
     for domain in domainsTLS:
         if domain in domainDBNoTLS:
             print_dbg("Delete domain %s from sqlite DB" % domain)
-            if not op['debug']:
+            if not args.debug:
                 c.execute('''DELETE FROM notlsDomains WHERE domain = ?;''', [domain])
     for domain in domainsNoTLS:
         if domain in domainsTLS:
@@ -241,7 +185,7 @@ def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
             # for the same domain were encrypted. TLS will be mandatory
             # in the future anyway for this domain.
             continue
-        op['summBody'] += "\n * %s" % (domain)
+        summary_lines.append(" * %s" % (domain))
         if domain in domainDBNoTLS:
             # send alerts every <alertTTL> days
             slist = domainDBNoTLS[domain]['alertDate'].split('-')
@@ -251,21 +195,23 @@ def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
                 continue
             else:
                 print_dbg("Update domain %s in sqlite DB" % domain)
-                if not op['debug']:
+                if not args.debug:
                     c.execute(
                         'UPDATE notlsDomains SET alertCount=?, alertDate=? WHERE domain = ?;',
                         (domainDBNoTLS[domain]['alertCount'] + 1, datetime.date.today(), domain))
         else:
             print_dbg("Insert domain %s into sqlite DB" % domain)
-            if not op['debug']:
+            if not args.debug:
                 c.execute('INSERT INTO notlsDomains (domain, alertCount, alertDate) '
                           'VALUES (?,?,?);', (domain, 1, datetime.date.today()))
-        if op['alerts']:
-            op['summBody'] += " [sent alert mail]"
-            sendMail(op['from'], ['postmaster@'+domain],
-                     op['alertSubj'].replace('XDOMAINX', domain),
-                     op['alertBody'].replace('XDOMAINX', domain))
-    op['summBody'] += "\n\n"
+        if args.send_alerts:
+            recipient = 'postmaster@{}'.format(domain)
+            summary_lines.append(" [sent alert mail: {}]".format(recipient))
+            sendMail(args.from_address, [recipient],
+                     args.alert_subject.replace('XDOMAINX', domain),
+                     args.alert_body.replace('XDOMAINX', domain))
+    summary_lines.append("")
+    summary_lines.append("")
     conn.commit()
     conn.close()
 
@@ -289,7 +235,7 @@ def sendMail(sender, to, subject, text, server="/usr/sbin/sendmail"):
     msg['Date'] = formatdate(localtime=True)
     msg['Subject'] = subject
     msg.attach(MIMEText(text))
-    if op['debug']:
+    if args.debug:
         print_dbg("Mail: %s" % msg.as_string())
     else:
         if server == "/usr/sbin/sendmail":
@@ -391,14 +337,15 @@ regex_exim4_smtp = re.compile(
 # Main function
 if __name__ == '__main__':
     # process commandline options
-    options(sys.argv[1:])
+    # TODO: remove the ugly implicit exposure of this variable to the other function
+    args = parse_args()
 
     # read in the whitelist
-    whitelist = readWhitelist(op['whitelist'])
+    whitelist = readWhitelist(args.whitelist_filename)
 
     # fill the relayDict by parsing mail logs
-    if op['mode'] == 'postfix':
-        relayDict = postfixParseLog(op['mailLog'], whitelist)
+    if args.mode == 'postfix':
+        relayDict = postfixParseLog(args.mail_logfile, whitelist)
 
     # fill domainsTLS and domainsNoTLS from relayDict
     domainsTLS = set()
@@ -415,21 +362,21 @@ if __name__ == '__main__':
                 domainsNoTLS.add(domain)
 
     # print a summary
-    op['summBody'] += "\n\n"
-    op['summBody'] += ("Total count of sent messages:             %s\n"
-                       % sentCountTotal)
-    op['summBody'] += ("Total count of messages sent without TLS: %s\n"
-                       % (sentCountTotal - sentCountTLS))
-    op['summBody'] += ("Percentage of messages sent without TLS:  %.2f%%\n"
-                       % ((sentCountTotal - sentCountTLS) / float(sentCountTotal) * 100))
+    summary_lines = []
+    summary_lines.append("Total count of sent messages:             %s" % sentCountTotal)
+    summary_lines.append("Total count of messages sent without TLS: %s"
+                         % (sentCountTotal - sentCountTLS))
+    summary_lines.append("Percentage of messages sent without TLS:  %.2f%%"
+                         % ((sentCountTotal - sentCountTLS) / float(sentCountTotal) * 100))
 
     # update the SQLite database with noTLS domains
     if len(domainsNoTLS) > 0:
-        notlsProcess(domainsTLS, domainsNoTLS, op['sqliteDB'])
+        notlsProcess(domainsTLS, domainsNoTLS, args.sqlite_db, summary_lines)
 
     # update the TLS policy map
-    if (op['mode'] == 'postfix') and op['postfixMap'] and (len(domainsTLS) > 0):
-        postfixTlsPolicyUpdate(domainsTLS, op['postfixMapFile'], op['postMap'])
+    if (args.mode == 'postfix') and args.use_postfix_map and (len(domainsTLS) > 0):
+        postfixTlsPolicyUpdate(domainsTLS, args.postfix_map_file, args.run_postmap)
 
-    if (len(domainsNoTLS) > 0) and op['summary']:
-        sendMail(op['from'], op['rcpts'], op['summSubj'], op['summBody'])
+    if (len(domainsNoTLS) > 0) and args.send_summary:
+        summary_text = args.summary_start + "\n\n" + "\n".join(summary_lines)
+        sendMail(args.from_address, args.recipients, args.summary_subject, summary_text)

--- a/mail-tls-helper.py
+++ b/mail-tls-helper.py
@@ -17,8 +17,10 @@
 from __future__ import print_function
 import os
 import re
-import datetime, sqlite3
-import getopt, sys
+import datetime
+import sqlite3
+import getopt
+import sys
 from collections import defaultdict
 from subprocess import call
 from subprocess import Popen, PIPE
@@ -26,7 +28,6 @@ import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.utils import COMMASPACE, formatdate
-import pprint
 
 name = "mail-tls-helper.py"
 version = "0.8.1"
@@ -35,6 +36,7 @@ alertTTL = 30
 
 global op
 op = {}
+
 
 # Structure for pidDict
 def relayFactory():
@@ -46,8 +48,10 @@ def relayFactory():
         'isTLS': False,
     }
 
+
 def pidFactory():
     return defaultdict(relayFactory)
+
 
 # Parse options
 def options(args):
@@ -55,11 +59,10 @@ def options(args):
     op['printVersion'] = False
 
     try:
-        opts, args = getopt.getopt(args, 'ad:f:hl:m:Op:Pr:s:SVw:',
-            ['alerts', 'domain=', 'debug', 'from=', 'help',
-             'mail-log=', 'mode=', 'no-postmap', 'postfix-map-file=',
-             'no-postfix-map', 'rcpts=', 'sqlite-db=', 'no-summary',
-             'version', 'whitelist='])
+        opts, args = getopt.getopt(args, 'ad:f:hl:m:Op:Pr:s:SVw:', [
+            'alerts', 'domain=', 'debug', 'from=', 'help', 'mail-log=', 'mode=', 'no-postmap',
+            'postfix-map-file=', 'no-postfix-map', 'rcpts=', 'sqlite-db=', 'no-summary', 'version',
+            'whitelist='])
     except getopt.error as exc:
         print("%s: %s, try -h for a list of all the options" % (name, str(exc)), file=sys.stderr)
         sys.exit(255)
@@ -75,7 +78,8 @@ def options(args):
             if (arg == 'postfix'):
                 op['mode'] = arg
             else:
-                print("%s: unknon mode %s, try -h for a list of all the options" % (name, arg), file=sys.stderr)
+                print("%s: unknon mode %s, try -h for a list of all the options" % (name, arg),
+                      file=sys.stderr)
                 sys.exit(255)
         elif opt in ['--debug']:
             op['debug'] = True
@@ -103,22 +107,23 @@ def options(args):
             op['rcpts'] = arg.split(',')
 
     # Set options to defaults if not set yet
-    op['debug']      = op.get('debug', False)
-    op['mode']       = op.get('mode', "postfix")
-    op['mailLog']    = op.get('mailLog', "/var/log/mail.log.1")
-    op['whitelist']  = op.get('whitelist', False)
+    op['debug'] = op.get('debug', False)
+    op['mode'] = op.get('mode', "postfix")
+    op['mailLog'] = op.get('mailLog', "/var/log/mail.log.1")
+    op['whitelist'] = op.get('whitelist', False)
     op['postfixMap'] = op.get('postfixMap', True)
     op['postfixMapFile'] = op.get('postfixMapFile', "/etc/postfix/tls_policy")
-    op['postMap']    = op.get('postMap', True)
-    op['sqliteDB']   = op.get('sqliteDB', "/var/lib/mail-tls-helper/notls.sqlite")
-    op['alerts']     = op.get('alerts', False)
-    op['summary']    = op.get('summary', True)
-    op['domain']     = op.get('domain', "example.org")
-    op['from']       = op.get('from', "admin@%s" % op['domain'])
-    op['rcpts']      = op.get('rcpts', [ "admin@%s" % op['domain'] ])
-    op['summSubj']  = op.get('sumSubj', "[%s] mail-tls-helper summary" % (os.uname()[1]))
-    op['summBody']  = op.get('sumSubj', "Summary mail by mail-tls-helper on %s" % (os.uname()[1]))
-    op['alertSubj'] = op.get('alertSubj', "Please add TLS support to the mailservers for 'XDOMAINX'")
+    op['postMap'] = op.get('postMap', True)
+    op['sqliteDB'] = op.get('sqliteDB', "/var/lib/mail-tls-helper/notls.sqlite")
+    op['alerts'] = op.get('alerts', False)
+    op['summary'] = op.get('summary', True)
+    op['domain'] = op.get('domain', "example.org")
+    op['from'] = op.get('from', "admin@%s" % op['domain'])
+    op['rcpts'] = op.get('rcpts', ["admin@%s" % op['domain']])
+    op['summSubj'] = op.get('sumSubj', "[%s] mail-tls-helper summary" % (os.uname()[1]))
+    op['summBody'] = op.get('sumSubj', "Summary mail by mail-tls-helper on %s" % (os.uname()[1]))
+    op['alertSubj'] = op.get('alertSubj',
+                             "Please add TLS support to the mailservers for 'XDOMAINX'")
     op['alertBody'] = op.get('alertBody', """Hello postmaster for mail domain 'XDOMAINX',
 
 Your mail server for 'XDOMAINX' is among the last mail servers,
@@ -163,7 +168,8 @@ Postfix helper script that does the following:
   -d, --domain=name            set organization domain (default: %s)
   -f, --from=address           set sender address (default: %s)
   -r, --rcpts=addresses        set summary mail rcpt addresses (default: %s)
-""" % (name, op['mode'], op['mailLog'], op['postfixMapFile'], op['sqliteDB'], op['domain'], op['from'], ','.join(op['rcpts'])), file=sys.stderr)
+""" % (name, op['mode'], op['mailLog'], op['postfixMapFile'], op['sqliteDB'], op['domain'],
+            op['from'], ','.join(op['rcpts'])), file=sys.stderr)
         sys.exit(0)
     elif op['printVersion']:
         print("%s %s" % (name, version), file=sys.stderr)
@@ -181,10 +187,11 @@ def print_dbg_pid(pid, dictx):
         if dictx[relay]['tlsCount'] != dictx[relay]['sentCount']:
             print_dbg_relay(relay, dictx[relay])
 
+
 def print_dbg_relay(relay, dictx):
     print_dbg(" relay: %s" % relay)
-    print_dbg("  domains: %s"   % dictx['domains'])
-    print_dbg("  tlsCount: %s"  % dictx['tlsCount'])
+    print_dbg("  domains: %s" % dictx['domains'])
+    print_dbg("  tlsCount: %s" % dictx['tlsCount'])
     print_dbg("  sentCount: %s" % dictx['sentCount'])
 
 
@@ -196,7 +203,8 @@ def postfixTlsPolicyUpdate(domainsTLS, postfixMapFile, postMap):
         for domain in domainsTLS:
             if domain not in policyFileLines:
                 print_dbg("Add domain '%s' to Postfix TLS policy map" % domain)
-                if not op['debug']: policyFile.write("%s encrypt\n" % domain)
+                if not op['debug']:
+                    policyFile.write("%s encrypt\n" % domain)
         policyFile.close()
 
     if postMap and not op['debug']:
@@ -204,7 +212,6 @@ def postfixTlsPolicyUpdate(domainsTLS, postfixMapFile, postMap):
 
 
 def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
-    # 
     domainDBNoTLS = {}
     if os.path.isfile(sqliteDB):
         conn = sqlite3.connect(sqliteDB)
@@ -221,11 +228,13 @@ def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
     op['summBody'] += "\nList of domains with no-TLS connections:"
     conn = sqlite3.connect(sqliteDB)
     c = conn.cursor()
-    c.execute('''CREATE TABLE IF NOT EXISTS notlsDomains (domain text, alertCount integer, alertDate date);''')
+    c.execute('CREATE TABLE IF NOT EXISTS notlsDomains '
+              '(domain text, alertCount integer, alertDate date);')
     for domain in domainsTLS:
         if domain in domainDBNoTLS:
             print_dbg("Delete domain %s from sqlite DB" % domain)
-            if not op['debug']: c.execute('''DELETE FROM notlsDomains WHERE domain = ?;''', [domain])
+            if not op['debug']:
+                c.execute('''DELETE FROM notlsDomains WHERE domain = ?;''', [domain])
     for domain in domainsNoTLS:
         if domain in domainsTLS:
             # ignore individual no-TLS connections when other connections
@@ -236,14 +245,21 @@ def notlsProcess(domainsTLS, domainsNoTLS, sqliteDB):
         if domain in domainDBNoTLS:
             # send alerts every <alertTTL> days
             slist = domainDBNoTLS[domain]['alertDate'].split('-')
-            if not datetime.date(int(slist[0]),int(slist[1]),int(slist[2])) < datetime.date.today()+datetime.timedelta(-alertTTL):
+            slist_date = datetime.date(int(slist[0]), int(slist[1]), int(slist[2]))
+            minimum_not_outdated_alert_date = datetime.date.today() - datetime.timedelta(alertTTL)
+            if slist_date >= minimum_not_outdated_alert_date:
                 continue
             else:
                 print_dbg("Update domain %s in sqlite DB" % domain)
-                if not op['debug']: c.execute('''UPDATE notlsDomains SET alertCount=?, alertDate=? WHERE domain = ?;''', (domainDBNoTLS[domain]['alertCount']+1, datetime.date.today(), domain))
+                if not op['debug']:
+                    c.execute(
+                        'UPDATE notlsDomains SET alertCount=?, alertDate=? WHERE domain = ?;',
+                        (domainDBNoTLS[domain]['alertCount'] + 1, datetime.date.today(), domain))
         else:
             print_dbg("Insert domain %s into sqlite DB" % domain)
-            if not op['debug']: c.execute('''INSERT INTO notlsDomains (domain, alertCount, alertDate) VALUES (?,?,?);''', (domain, 1, datetime.date.today()))
+            if not op['debug']:
+                c.execute('INSERT INTO notlsDomains (domain, alertCount, alertDate) '
+                          'VALUES (?,?,?);', (domain, 1, datetime.date.today()))
         if op['alerts']:
             op['summBody'] += " [sent alert mail]"
             sendMail(op['from'], ['postmaster@'+domain],
@@ -266,7 +282,7 @@ def readWhitelist(wlfile):
 
 
 def sendMail(sender, to, subject, text, server="/usr/sbin/sendmail"):
-    assert type(to)==list
+    assert type(to) == list
     msg = MIMEMultipart()
     msg['From'] = sender
     msg['To'] = COMMASPACE.join(to)
@@ -293,17 +309,20 @@ def sendMail(sender, to, subject, text, server="/usr/sbin/sendmail"):
 
 def postfixParseLog(logfile, whitelist):
     # Postfix regexes
-    regex_smtp = re.compile(r" postfix/smtp\[(?P<pid>[0-9]+)\]: (?P<msgid>[0-9A-F]+): to=<[^@]+@(?P<domain>[^, ]+)>, .*relay=(?P<relay>[\w\-\.]+)\[[0-9A-Fa-f\.:]+\]:[0-9]{1,5}, .*status=(?P<status>[a-z]+)")
-    regex_tls  = re.compile(r" postfix/smtp\[(?P<pid>[0-9]+)\]: .*TLS connection established to (?P<relay>[\w\-\.]+)\[[0-9A-Fa-f\.:]+\]:[0-9]{1,5}")
+    regex_smtp = re.compile(r" postfix/smtp\[(?P<pid>[0-9]+)\]: "
+                            r"(?P<msgid>[0-9A-F]+): to=<[^@]+@(?P<domain>[^, ]+)>, .*"
+                            r"relay=(?P<relay>[\w\-\.]+)\[[0-9A-Fa-f\.:]+\]:[0-9]{1,5}, .*"
+                            r"status=(?P<status>[a-z]+)")
+    regex_tls = re.compile(r" postfix/smtp\[(?P<pid>[0-9]+)\]: .*TLS connection established to "
+                           r"(?P<relay>[\w\-\.]+)\[[0-9A-Fa-f\.:]+\]:[0-9]{1,5}")
 
     # Read SMTP client connections from Postfix logfile into pidDict
-    # * SMTP client connection logs don't contain TLS evidence. Thus
-    #   TLS connections logs have to be parsed alongside.
+    # * SMTP client connection logs don't contain TLS evidence. Thus TLS connections logs have to
+    #   be parsed alongside.
     # * Beware:
-    #   * Postfix sends several mails - even to different relays - under one
-    #     PID, each one with a separate msgID.
-    #   * Several connections may exist per msgID (e.g. if first attempt to
-    #     send fails).
+    #   * Postfix sends several mails - even to different relays - under one PID, each one with a
+    #     separate msgID.
+    #   * Several connections may exist per msgID (e.g. if first attempt to send fails).
     #   * One TLS connection may be used to send several mails to one relay.
     # * What we do:
     #   * Pair PID and relay, write stats for that pair into pidDict[relay]
@@ -343,28 +362,31 @@ def postfixParseLog(logfile, whitelist):
     # Transform pidDict into relayDict
     relayDict = defaultdict(relayFactory)
     for pid in pidDict:
-        #print_dbg_pid(pid, pidDict[pid])
+        # optional PID output: print_dbg_pid(pid, pidDict[pid])
         for relay in pidDict[pid]:
             for x in pidDict[pid][relay]['domains']:
                 relayDict[relay]['domains'].add(x)
             relayDict[relay]['sentCount'] += pidDict[pid][relay]['sentCount']
-            
-            if (pidDict[pid][relay]['tlsCount'] > 0 and
-                pidDict[pid][relay]['sentCount'] > 0):
+
+            if (pidDict[pid][relay]['tlsCount'] > 0) and (pidDict[pid][relay]['sentCount'] > 0):
                 # At least one encrypted connection and one delivered message
                 relayDict[relay]['sentCountTLS'] += pidDict[pid][relay]['sentCount']
                 relayDict[relay]['isTLS'] = True
             elif (pidDict[pid][relay]['tlsCount'] > 0):
                 # No message got delivered, still encrypted connection: ignore
                 relayDict[relay]['isTLS'] = True
-            #else:
+            else:
                 # Only unencrypted connections
+                pass
 
     return relayDict
 
 
 # Untested Exim4 regexes:
-regex_exim4_smtp = re.compile(r"(?P<msgid>[\w\-]{14}) [=-]> .*T=remote_smtp .*H=(?P<relay>[\w\-\.]+) .*(X=(?P<tlsver>[A-Z0-9\.]+):[\w\-\.:_]+)? .*C=\"(?P<response>[^\"]+)\"")
+regex_exim4_smtp = re.compile(
+    r'(?P<msgid>[\w\-]{14}) [=-]> .*T=remote_smtp .*H=(?P<relay>[\w\-\.]+) .*'
+    r'(X=(?P<tlsver>[A-Z0-9\.]+):[\w\-\.:_]+)? .*C="(?P<response>[^"]+)"')
+
 
 # Main function
 if __name__ == '__main__':
@@ -379,12 +401,12 @@ if __name__ == '__main__':
         relayDict = postfixParseLog(op['mailLog'], whitelist)
 
     # fill domainsTLS and domainsNoTLS from relayDict
-    domainsTLS   = set()
+    domainsTLS = set()
     domainsNoTLS = set()
     sentCountTotal = sentCountTLS = 0
     for relay in relayDict:
         sentCountTotal += relayDict[relay]['sentCount']
-        sentCountTLS   += relayDict[relay]['sentCountTLS']
+        sentCountTLS += relayDict[relay]['sentCountTLS']
         if relayDict[relay]['isTLS']:
             for domain in relayDict[relay]['domains']:
                 domainsTLS.add(domain)
@@ -393,17 +415,21 @@ if __name__ == '__main__':
                 domainsNoTLS.add(domain)
 
     # print a summary
-    op['summBody'] += "\n\nTotal count of sent messages:             %s\n" % sentCountTotal
-    op['summBody'] += "Total count of messages sent without TLS: %s\n" % (sentCountTotal-sentCountTLS)
-    op['summBody'] += "Percentage of messages sent without TLS:  %.2f%%\n" % ((sentCountTotal-sentCountTLS)/float(sentCountTotal)*100)
+    op['summBody'] += "\n\n"
+    op['summBody'] += ("Total count of sent messages:             %s\n"
+                       % sentCountTotal)
+    op['summBody'] += ("Total count of messages sent without TLS: %s\n"
+                       % (sentCountTotal - sentCountTLS))
+    op['summBody'] += ("Percentage of messages sent without TLS:  %.2f%%\n"
+                       % ((sentCountTotal - sentCountTLS) / float(sentCountTotal) * 100))
 
     # update the SQLite database with noTLS domains
     if len(domainsNoTLS) > 0:
         notlsProcess(domainsTLS, domainsNoTLS, op['sqliteDB'])
 
     # update the TLS policy map
-    if (op['mode'] == 'postfix' and op['postfixMap'] and len(domainsTLS) > 0):
+    if (op['mode'] == 'postfix') and op['postfixMap'] and (len(domainsTLS) > 0):
         postfixTlsPolicyUpdate(domainsTLS, op['postfixMapFile'], op['postMap'])
 
-    if (len(domainsNoTLS) > 0 and op['summary']):
-        sendMail(op['from'],op['rcpts'],op['summSubj'],op['summBody'])
+    if (len(domainsNoTLS) > 0) and op['summary']:
+        sendMail(op['from'], op['rcpts'], op['summSubj'], op['summBody'])


### PR DESCRIPTION
Replace the getopt argument handling (including the manually written 'help' output) with argparse.

Hint: this branch is based on #11.

Relevent changes:
* `summSubj` and `summBody` *looked* configurable before, but they were not, since `sumObj` (single "m") was undefined under all circumstances. They do not pretend to be configurable anymore.
* `alertSubj` and `alertBody`: more or less the same as `summSubj`/`summBody` (was also not configurable)
* the assembly of the mail summary text does not rely on an implicit global variable (`op['summBody']`) anymore