### PR TITLE
improve TLS policy file handling

### DIFF
--- a/mail-tls-helper.py
+++ b/mail-tls-helper.py
@@ -191,13 +191,19 @@ def print_dbg_relay(relay, dictx):
 # Postfix TLS policy table functions
 def postfixTlsPolicyUpdate(domainsTLS, postfixMapFile, postMap):
     if os.path.isfile(postfixMapFile):
-        policyFileLines = [line.split()[0] for line in open(postfixMapFile, 'r')]
-        policyFile = open(postfixMapFile, 'a')
-        for domain in domainsTLS:
-            if domain not in policyFileLines:
-                print_dbg("Add domain '%s' to Postfix TLS policy map" % domain)
-                if not op['debug']: policyFile.write("%s encrypt\n" % domain)
-        policyFile.close()
+        existing_policy_domains = set()
+        with open(postfixMapFile, 'r') as in_file:
+            for line in in_file:
+                if line.strip():
+                    domain = line.strip().split()[0]
+                    existing_policy_domains.add(domain)
+        missing_policy_domains = domainsTLS.difference(existing_policy_domains)
+        if missing_policy_domains:
+            with open(postfixMapFile, 'a') as policyFile:
+                for domain in missing_policy_domains:
+                    print_dbg("Add domain '%s' to Postfix TLS policy map" % domain)
+                    if not op['debug']:
+                        policyFile.write("%s encrypt\n" % domain)
 
     if postMap and not op['debug']:
         call(["postmap", postfixMapFile])


### PR DESCRIPTION
The following details change:
* handle empty lines gracefully (they are allowed by the file format)
* close file after reading
* change modification time of policy file only in case of real changes
* use "set" operations instead of manual list iteration