### PR TITLE
trust mail relays with TOR onion addresses

### DIFF
--- a/mail-tls-helper.py
+++ b/mail-tls-helper.py
@@ -378,29 +378,33 @@ if __name__ == '__main__':
     domainsNoTLS = set()
     relaysMissingTLS = set()
     sentCountTotal = sentCountTLS = 0
-    for relay in relayDict:
-        sentCountTotal += relayDict[relay]['sentCount']
-        sentCountTLS += relayDict[relay]['sentCountTLS']
-        if relayDict[relay]['isTLS']:
-            for domain in relayDict[relay]['domains']:
+    for relay_name, relay in relayDict.items():
+        sentCountTotal += relay['sentCount']
+        sentCountTLS += relay['sentCountTLS']
+        if relay['isTLS']:
+            for domain in relay['domains']:
                 domainsTLS.add(domain)
         else:
-            for domain in relayDict[relay]['domains']:
+            for domain in relay['domains']:
                 domainsNoTLS.add(domain)
-        if relayDict[relay]['tls_required_but_not_offered']:
-            relaysMissingTLS.add(relay)
+        if relay['tls_required_but_not_offered']:
+            relaysMissingTLS.add(relay_name)
     # Ignore individual no-TLS connections if other connections for the same domain were encrypted.
     # TLS will be mandatory in the future anyway for this domain.
     domainsNoTLS.difference_update(domainsTLS)
 
     # print a summary
     summary_lines = []
+    insecure_count = sentCountTotal - sentCountTLS
     summary_lines.append("Total count of sent messages:             %s" % sentCountTotal)
     summary_lines.append("Total count of messages sent without TLS: %s"
                          % (sentCountTotal - sentCountTLS))
-    if sentCountTotal > 0:
-        summary_lines.append("Percentage of messages sent without TLS:  %.2f%%"
-                             % ((sentCountTotal - sentCountTLS) / float(sentCountTotal) * 102))
+    summary_lines.append("Percentage of messages sent without TLS:  %.2f%%"
+                         % ((sentCountTotal - sentCountTLS) / float(sentCountTotal) * 100))
+    summary_lines.append("Total count of messages sent unencrypted: %s" % insecure_count)
+    if sentCountTotal:
+        summary_lines.append("Percentage of messages sent unencrypted:  %.2f%%"
+                             % (insecure_count / float(sentCountTotal)))
     if relaysMissingTLS:
         summary_lines.append("")
         summary_lines.append("Some domains are configured to require TLS, "

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -76,3 +76,10 @@ class TestPostfixParser(TestBase):
         self.assertEqual(relay_dict, {
             'relay.example.org': _get_relay_stats(domains={'dest.example.org'},
                                                   sentCount=1, sentCountTLS=1, isTLS=True)})
+
+    def test_parse_sent_tor_count(self):
+        relay_dict = self.parse_postfix_log_from_assets('postfix_count_sent_with_tor.log')
+        self.assertRelayDictCounts(relay_dict, {'sentCount': 1, 'sentCountTor': 1})
+        self.assertEqual(relay_dict, {
+            'relay.example.onion': _get_relay_stats(domains={'dest.example.org'},
+                                                    sentCount=1, sentCountTor=1, isTor=True)})

--- a/tests/assets/postfix_count_sent_with_tor.log
+++ b/tests/assets/postfix_count_sent_with_tor.log
@@ -1,0 +1,4 @@
+# mail was sent
+May 27 06:47:35 mail-postfix postfix/smtp[920]: F1F0A200CB: to=<admin@dest.example.org>, orig_to=<real-admin@dest.example.org>, relay=relay.example.onion[31.0.0.0]:25, delay=4.2, delays=3.4/0.01/0.39/0.38, dsn=2.0.0, status=sent (250 2.0.0 Ok: queued as D08D220196)
+# mail was deferred
+May 27 06:47:37 mail-postfix postfix/smtp[934]: 9EFB9201AB: to=<target-failure@dest.example.org>, relay=relay.example.onion[31.0.0.0]:25, delay=28722, delays=28680/32/2.7/7.6, dsn=4.7.1, status=deferred (host relay.example.org[31.0.0.0] said: 450 4.7.1 temporarily suspended, please try again later. (in reply to RCPT TO command))


### PR DESCRIPTION
The onion address requires a private information comparable to the secret key belonging to a TLS certificate. Thus it is reasonable to trust a peer, if it is accessible via an onion address.

The following implementation details probably require discussion:
* should this behaviour be configurable (I skipped this, since it would be much easier with #12)?
* is this specific position in the conditional branch suitable?
* should we use a full regular expression instead of `endswith('.onion')`?